### PR TITLE
webpack: Add error handling around HtmlWebpackPlugin hooks and entryPath not being found

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ None of the options are required, by default the page will render when puppeteer
 
 ### `@prerenderer/webpack-plugin` Options
 
+You _MUST_ use [HtmlWebpackPlugin](https://github.com/jantimon/html-webpack-plugin) as this plugin is triggered after.
+
 None of the options are required, by default the renderer-puppeteer will be used and render only the entry file
 | Option          | Type                             | Default                             | Description                                                                                             |
 |-----------------|----------------------------------|-------------------------------------|---------------------------------------------------------------------------------------------------------|

--- a/packages/webpack-plugin/README.md
+++ b/packages/webpack-plugin/README.md
@@ -3,7 +3,7 @@
 This package is part of the `@prerenderer` monorepo, for the rest of the documentation head over to https://github.com/Tofandel/prerenderer#prerendererwebpack-plugin-options
 
 ### Requirements
-This plugin is for webpack 5 and requires the html-webpack-plugin to be setup
+This plugin is for webpack 5 and you _MUST_ use [HtmlWebpackPlugin](https://github.com/jantimon/html-webpack-plugin) as this plugin is triggered after.
 
 ### Installation
 `npm i -D @prerenderer/webpack-plugin @prerenderer/renderer-puppeteer`


### PR DESCRIPTION
I'm migrating from prerender-spa-plugin and I wasn't aware that HtmlWebpackPlugin was required. I had to do a lot of debugging before I realized why this plugin was silently doing nothing. I updated the documentation a bit and added some errors for plugin users so they do not get stuck like I did!

This PR addresses three things:
- makes it ultra clear that HtmlWebpackPlugin is required and why
- logging an error if during compilation if HtmlWebpackPlugin is not used -- if you don't use the HtmlWebpackPlugin, the `afterEmit` hook doesn't do anything and the plugin silently does nothing
- logging an error if the entryPath is not found in the assets. I got stuck on this for a bit and had to do debugging to find out why the plugin was doing nothing and logging nothing.